### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,9 @@
         <li class="nav-item">
           <a class="nav-link" href="#contacto">Contacto</a>
         </li>
+        <li class="nav-item">
+          <button id="themeToggle" class="btn btn-link nav-link">Modo oscuro</button>
+        </li>
       </ul>
     </div>
   </div>
@@ -135,5 +138,6 @@
 
 <!-- JS Bootstrap -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,10 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+    });
+  }
+});
+

--- a/styles.css
+++ b/styles.css
@@ -107,3 +107,30 @@ section {
   padding: 1rem 0;
   border-top: 1px solid #ddd;
 }
+
+/* Dark mode */
+body.dark-mode {
+  background-color: #121212;
+  color: #f1f1f1;
+}
+
+body.dark-mode .navbar {
+  background-color: #333 !important;
+}
+
+body.dark-mode .navbar-light .navbar-nav .nav-link {
+  color: #f1f1f1 !important;
+}
+
+body.dark-mode .navbar-light .navbar-nav .nav-link:hover {
+  color: #FFC107 !important;
+}
+
+body.dark-mode .bg-light {
+  background-color: #1e1e1e !important;
+}
+
+body.dark-mode footer.bg-dark {
+  background-color: #000 !important;
+}
+


### PR DESCRIPTION
## Summary
- add a dark mode toggle button in navbar
- include script.js and implement dark mode toggle logic
- provide dark mode styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866592ffe608327a39c9179074ee0b8