### PR TITLE
Add catch-all 404 rule

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -12,4 +12,5 @@
 # Redirecciones 404 para URLs PHP antiguas
 /parking.php / 404
 /search/portal.php / 404
-/search/cc.php / 404 
+/search/cc.php / 404
+/* /404.html 404


### PR DESCRIPTION
## Summary
- add generic rule in `_redirects` sending all unmatched URLs to `404.html`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68665de03f448327b7dcc8d3fed4d5c7