### PR TITLE
Fix missing logo and favicon asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="PlazaSys — Automatización industrial, IoT, ingeniería mecánica y prototipado de máquinas. Resolvemos problemas industriales en Ontinyent, Valencia.">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#F9D815">
-    <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
     <link rel="canonical" href="https://plazasys.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -187,7 +187,7 @@
 <body>
 
 <nav class="nav"><div class="nav-in">
-    <a href="#inicio"><img src="assets/logo.svg" alt="PlazaSys" class="logo-img"></a>
+    <a href="#inicio"><img src="logo.svg" alt="PlazaSys" class="logo-img"></a>
     <ul class="nav-l" id="navL"><li><a href="#inicio" class="active">Inicio</a></li><li><a href="#servicios">Servicios</a></li><li><a href="#nosotros">Nosotros</a></li><li><a href="#contacto">Contacto</a></li></ul>
     <div class="nav-r"><div class="dot-on"></div>Online</div>
     <button class="burger" id="burg" aria-label="Menú"><svg viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg></button>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="48" viewBox="0 0 220 48" role="img" aria-labelledby="title desc">
+  <title id="title">PlazaSys Logo</title>
+  <desc id="desc">Logotipo de PlazaSys con símbolo amarillo y texto en gris oscuro.</desc>
+  <rect x="0" y="4" width="40" height="40" rx="10" fill="#F9D815"/>
+  <path d="M10 26h20" stroke="#1C1C1A" stroke-width="3" stroke-linecap="round"/>
+  <path d="M20 16v20" stroke="#1C1C1A" stroke-width="3" stroke-linecap="round"/>
+  <text x="52" y="31" fill="#3E3E3D" font-family="Instrument Sans, Arial, sans-serif" font-size="24" font-weight="700">PlazaSys</text>
+</svg>

--- a/nuevo/index.html
+++ b/nuevo/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="PlazaSys — Automatización industrial, IoT, ingeniería mecánica y prototipado de máquinas. Resolvemos problemas industriales en Ontinyent, Valencia.">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#F9D815">
-    <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="../favicon.ico" type="image/x-icon">
     <link rel="canonical" href="https://plazasys.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -195,7 +195,7 @@
 <body>
 
 <nav class="nav"><div class="nav-in">
-    <a href="#inicio"><img src="../assets/logo.svg" alt="PlazaSys" class="logo-img"></a>
+    <a href="#inicio"><img src="../logo.svg" alt="PlazaSys" class="logo-img"></a>
     <ul class="nav-l" id="navL"><li><a href="#inicio" class="active">Inicio</a></li><li><a href="#servicios">Servicios</a></li><li><a href="#nosotros">Nosotros</a></li><li><a href="#contacto">Contacto</a></li></ul>
     <div class="nav-r"><div class="dot-on"></div>Online</div>
     <button class="burger" id="burg" aria-label="Menú"><svg viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg></button>

--- a/plazasys-v8.html
+++ b/plazasys-v8.html
@@ -7,7 +7,7 @@
     <meta name="description" content="PlazaSys — Automatización industrial, IoT, ingeniería mecánica y prototipado de máquinas. Resolvemos problemas industriales en Ontinyent, Valencia.">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#F9D815">
-    <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
     <link rel="canonical" href="https://plazasys.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -187,7 +187,7 @@
 <body>
 
 <nav class="nav"><div class="nav-in">
-    <a href="#inicio"><img src="assets/logo.svg" alt="PlazaSys" class="logo-img"></a>
+    <a href="#inicio"><img src="logo.svg" alt="PlazaSys" class="logo-img"></a>
     <ul class="nav-l" id="navL"><li><a href="#inicio" class="active">Inicio</a></li><li><a href="#servicios">Servicios</a></li><li><a href="#nosotros">Nosotros</a></li><li><a href="#contacto">Contacto</a></li></ul>
     <div class="nav-r"><div class="dot-on"></div>Online</div>
     <button class="burger" id="burg" aria-label="Menú"><svg viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg></button>


### PR DESCRIPTION
### Motivation

- Las páginas referenciaban `assets/logo.svg` y `assets/favicon.ico` pero esos archivos no existían en `assets/`, lo que provocaba que el logo y el favicon no se mostraran.

### Description

- Cambié las referencias en `index.html`, `plazasys-v8.html` y `nuevo/index.html` para apuntar a `logo.svg`/`favicon.ico` en las rutas correctas (`logo.svg` y `favicon.ico` en la raíz, y `../logo.svg`/`../favicon.ico` desde `nuevo/`).
- Añadí un nuevo archivo `logo.svg` en la raíz del repo para que el header muestre el logotipo sin modificar el resto del HTML o estilos.

### Testing

- Busqué referencias rotas con `rg -n "assets/(logo\.svg|favicon\.ico)"` y verifiqué que ya no quedan referencias a `assets/` (éxito).
- Comprobé la existencia de cada recurso relativo usando un pequeño script Python que valida que `index.html` y `plazasys-v8.html` resuelven a `logo.svg` y `favicon.ico`, y que `nuevo/index.html` resuelve a `../logo.svg` y `../favicon.ico` (éxito).
- Inspeccioné los archivos modificados `index.html`, `plazasys-v8.html`, `nuevo/index.html` y el nuevo `logo.svg` para confirmar que solo se tocaron las rutas de los assets y se añadió el SVG (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ba8a8c648327b2abea398421112c)