### PR TITLE
Use plazasys-logo.svg in navigation header

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 <body>
 
 <nav class="nav"><div class="nav-in">
-    <a href="#inicio"><img src="logo.svg" alt="PlazaSys" class="logo-img"></a>
+    <a href="#inicio"><img src="plazasys-logo.svg" alt="PlazaSys" class="logo-img"></a>
     <ul class="nav-l" id="navL"><li><a href="#inicio" class="active">Inicio</a></li><li><a href="#servicios">Servicios</a></li><li><a href="#nosotros">Nosotros</a></li><li><a href="#contacto">Contacto</a></li></ul>
     <div class="nav-r"><div class="dot-on"></div>Online</div>
     <button class="burger" id="burg" aria-label="Menú"><svg viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg></button>

--- a/plazasys-v8.html
+++ b/plazasys-v8.html
@@ -187,7 +187,7 @@
 <body>
 
 <nav class="nav"><div class="nav-in">
-    <a href="#inicio"><img src="logo.svg" alt="PlazaSys" class="logo-img"></a>
+    <a href="#inicio"><img src="plazasys-logo.svg" alt="PlazaSys" class="logo-img"></a>
     <ul class="nav-l" id="navL"><li><a href="#inicio" class="active">Inicio</a></li><li><a href="#servicios">Servicios</a></li><li><a href="#nosotros">Nosotros</a></li><li><a href="#contacto">Contacto</a></li></ul>
     <div class="nav-r"><div class="dot-on"></div>Online</div>
     <button class="burger" id="burg" aria-label="Menú"><svg viewBox="0 0 24 24"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg></button>


### PR DESCRIPTION
### Motivation
- Ensure the navigation header uses the correct logo asset (`plazasys-logo.svg`) instead of the outdated `logo.svg` for consistent branding.

### Description
- Updated the `<img src="...">` on the navigation bar in `index.html` and `plazasys-v8.html` to reference `plazasys-logo.svg`, leaving the `favicon.ico` configuration unchanged.

### Testing
- Verified references with `rg -n 'plazasys-logo\.svg|favicon\.ico|logo\.svg' index.html plazasys-v8.html` and confirmed only the expected logo path updates were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c07566b0832797d4cd0826f611de)