### PR TITLE
Fix favicon path and declarations on all HTML entry pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <title>404 - Página no encontrada</title>
     <style>
         body {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <meta name="description" content="PlazaSys — Automatización industrial, IoT, ingeniería mecánica y prototipado de máquinas. Resolvemos problemas industriales en Ontinyent, Valencia.">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#F9D815">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="canonical" href="https://plazasys.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/plazasys-v8.html
+++ b/plazasys-v8.html
@@ -7,7 +7,8 @@
     <meta name="description" content="PlazaSys — Automatización industrial, IoT, ingeniería mecánica y prototipado de máquinas. Resolvemos problemas industriales en Ontinyent, Valencia.">
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#F9D815">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="canonical" href="https://plazasys.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
### Motivation
- The site used a relative favicon path (`href="favicon.ico"`) which can fail on non-root routes and prevent the icon from appearing. 
- The `404.html` page had no favicon link so error pages could miss the site icon.

### Description
- Replaced relative `href="favicon.ico"` with absolute `href="/favicon.ico"` in `index.html` and `plazasys-v8.html`.
- Added both `<link rel="icon" href="/favicon.ico" sizes="any">` and `<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">` to the modified pages for broader browser compatibility.
- Inserted the same favicon declarations into `404.html` so the error page also displays the site icon.

### Testing
- Verified the new links are present using `rg -n 'rel="(icon|shortcut icon)"' index.html plazasys-v8.html 404.html`, which returned the expected matches. 
- Reviewed the change set with `git diff -- index.html plazasys-v8.html 404.html` and confirmed the expected insertions and deletions. 
- Saved and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c1542e0c832788d12a3b2a23b255)